### PR TITLE
Make all tests pass.

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -26,7 +26,7 @@ there are key events. We need a `GamepadRegistry` singleton that lives in the
 
 [ShortcutRegistry]:https://developers.google.com/blockly/reference/js/Blockly.ShortcutRegistry
 
-## Gamepad shortcut type
+## ~~Gamepad shortcut type~~ DONE!
 
 The `NavigationController` uses an interface call
 `Blockly.ShortcutRegistry.KeyboardShortcut`. We need an equivalent called
@@ -39,8 +39,61 @@ are registered directly in the `NavigationController`. This makes the
 `NavigationController` quite long, and hard to test. Let's move all the
 shortcuts out into their own classes with a clean interface.
 
-## Test updates
+## ~~Test updates~~ DONE!
 
 All unit tests also need to be updated to account for changes moving forward. To
 ensure that the tests are passing moving forward, I will add the tests as a
 precommit check.
+
+## No singletons
+
+Singletons make it harder to test changes, and make code less flexible.
+Currently, the `AccessibilityStatus` class is a singleton. This is because of
+the way the gesture_monkey_patch.js file is written. If you change it to be a
+proper instantiable class, then you can also make `AccessibilityStatus` a
+non-singleton.
+
+## GamepadButton type needs a new name
+
+The `GamepadButton` button type's name clashes with the `GamepadButton` type
+specified in the browser. Coming up with a new name will just cut down on
+confusion.
+
+## Documentation of controls
+
+Right now, the commands are undocumented. Ideally, you could overlay the
+commands on an image of a gamepad.
+
+## Customizable controls
+
+The controls should be customizable so the user can optimize their workflow.
+
+## Change test_helper.createNavigationWorkspace to use `NavigationController`
+
+Right now, it uses `Navigation`, and enables gamepad navigation directly on the
+`Navigation`. This was fine for keyboard navigation, because the controller
+never had to enable navigation on anything besides `Navigation`. However, we
+also now have `GamepadMonitor`.
+
+This also ties into cleaning up resource management so that test suites are
+flatter, and easier to make sense of. Right now, in some cases workspaces are
+being disposed twice.
+
+## Investigate skipped test
+
+There is one test that is being skipped no matter what. But, I'm not sure what
+test it is.
+
+## Manual testing
+
+Need to some manual testing of all features to make sure they are working as
+intended, even though all of the tests are passing.
+
+## Text input
+
+Investigate best ways to input text with a game controller. Maybe a wheel that
+lets you quickly jump between letters? Suggest words based on a dictionary?
+
+## Auto-formatting
+
+Add [prettier][prettier] to the project so that code is automatically formatted.

--- a/NOTES.md
+++ b/NOTES.md
@@ -39,7 +39,11 @@ are registered directly in the `NavigationController`. This makes the
 `NavigationController` quite long, and hard to test. Let's move all the
 shortcuts out into their own classes with a clean interface.
 
-## ~~Test updates~~ DONE!
+## ~~Make tests pass~~ DONE!
+
+Make any code changes necessary to get tests to pass.
+
+## ~~Unit test presubmit check~~ DONE!
 
 All unit tests also need to be updated to account for changes moving forward. To
 ensure that the tests are passing moving forward, I will add the tests as a

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,42 @@
+const webpack = require('webpack');
+
+process.env.CHROME_BIN = require('puppeteer').executablePath();
+
+module.exports = function(config) {
+  config.set({
+    frameworks: ['mocha', 'chai', 'webpack'],
+    plugins: [
+      'karma-webpack',
+      'karma-mocha',
+      'karma-chai',
+      'karma-chrome-launcher',
+    ],
+    preprocessors: {
+      'test/**/*.mocha.js': ['webpack'],
+    },
+    files: [{
+      pattern: 'test/**/*.mocha.js',
+      type: 'module',
+    }],
+    reporters: ['progress'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    browsers: ['ChromeHeadless'],
+    autoWatch: false,
+    concurrency: Infinity,
+    webpack: {
+      plugins: [
+        new webpack.SourceMapDevToolPlugin({
+          filename: null, // if no value is provided the sourcemap is inlined
+          test: /\.(ts|js)($|\?)/i, // process .js and .ts files only
+        }),
+      ],
+    },
+    client: {
+      mocha: {
+        ui: 'tdd',
+      },
+    },
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,21 @@
       "devDependencies": {
         "@blockly/dev-scripts": "^1.2.6",
         "@blockly/dev-tools": "^2.3.0",
+        "@sinonjs/fake-timers": "^6.0.1",
         "blockly": "^5.20210325.0",
         "chai": "^4.2.0",
+        "global-jsdom": "^8.1.0",
         "husky": "^6.0.0",
         "jsdom": "^16.4.0",
-        "jsdom-global": "^3.0.2",
+        "karma": "^6.3.3",
+        "karma-chai": "^0.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-mocha": "^2.0.1",
+        "karma-webpack": "^5.0.0",
         "mocha": "^7.1.0",
-        "sinon": "^9.0.1"
+        "puppeteer": "^10.0.0",
+        "sinon": "^9.0.1",
+        "webpack": "^4.46.0"
       },
       "engines": {
         "node": ">=8.17.0"
@@ -1552,6 +1560,24 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "node_modules/@types/component-emitter": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==",
+      "dev": true
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "dev": true
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
+      "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
+      "dev": true
+    },
     "node_modules/@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1585,6 +1611,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
       "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A==",
       "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
@@ -1967,6 +2003,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2407,6 +2455,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2426,6 +2483,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -2468,6 +2534,55 @@
       "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/blockly": {
@@ -2935,6 +3050,15 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -3449,6 +3573,15 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3554,6 +3687,21 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
@@ -3562,6 +3710,21 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/connect/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/connect/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -3684,6 +3847,19 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -3787,6 +3963,12 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
+    "node_modules/custom-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "dev": true
+    },
     "node_modules/cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -3823,6 +4005,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/debug": {
@@ -4018,6 +4209,18 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.883894",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.883894.tgz",
+      "integrity": "sha512-33idhm54QJzf3Q7QofMgCvIVSd2o9H3kQPWaKT/fhoZh+digc+WSiMhbkeG3iN79WY4Hwr9G05NpbhEVrsOYAg==",
+      "dev": true
+    },
+    "node_modules/di": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+      "dev": true
+    },
     "node_modules/diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -4079,6 +4282,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-serialize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+      "dev": true,
+      "dependencies": {
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "node_modules/domain-browser": {
@@ -4200,6 +4415,66 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/engine.io": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~4.0.0",
+        "ws": "~7.4.2"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
+      "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+      "dev": true,
+      "dependencies": {
+        "base64-arraybuffer": "0.1.4"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
@@ -4238,6 +4513,12 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
     },
     "node_modules/errno": {
       "version": "0.1.8",
@@ -5148,6 +5429,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -5185,6 +5501,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/figgy-pudding": {
@@ -5501,6 +5826,12 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -5656,6 +5987,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/global-jsdom": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-8.1.0.tgz",
+      "integrity": "sha512-FBi84GT/MrzP+H3aReBSWXGVz2kdPaDrK/DByKrOq16mRexWrcJNpV6SONCKXWQuzxRjA7UXMfIvxmGyQZS+2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "jsdom": ">=10.0.0 || <17"
       }
     },
     "node_modules/global-modules": {
@@ -6045,6 +6388,19 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/husky": {
       "version": "6.0.0",
@@ -6577,6 +6933,18 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "node_modules/isbinaryfile": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
+      "integrity": "sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -6671,12 +7039,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jsdom-global": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
-      "dev": true
     },
     "node_modules/jsdom/node_modules/acorn-globals": {
       "version": "6.0.0",
@@ -6911,6 +7273,310 @@
       "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
     },
+    "node_modules/karma": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.3.tgz",
+      "integrity": "sha512-JRAujkKWaOtO2LmyPH7K2XXRhrxuFAn9loIL9+iiah6vjz+ZLkqdKsySV9clRITGhj10t9baIfbCl6CJ5hu9gQ==",
+      "dev": true,
+      "dependencies": {
+        "body-parser": "^1.19.0",
+        "braces": "^3.0.2",
+        "chokidar": "^3.4.2",
+        "colors": "^1.4.0",
+        "connect": "^3.7.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.1",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
+        "http-proxy": "^1.18.1",
+        "isbinaryfile": "^4.0.6",
+        "lodash": "^4.17.19",
+        "log4js": "^6.2.1",
+        "mime": "^2.4.5",
+        "minimatch": "^3.0.4",
+        "qjobs": "^1.2.0",
+        "range-parser": "^1.2.1",
+        "rimraf": "^3.0.2",
+        "socket.io": "^3.1.0",
+        "source-map": "^0.6.1",
+        "tmp": "0.2.1",
+        "ua-parser-js": "^0.7.23",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "karma": "bin/karma"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/karma-chai": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/karma-chai/-/karma-chai-0.1.0.tgz",
+      "integrity": "sha1-vuWtQEAFF4Ea40u5RfdikJEIt5o=",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "*",
+        "karma": ">=0.10.9"
+      }
+    },
+    "node_modules/karma-chrome-launcher": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
+      "integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
+      "dev": true,
+      "dependencies": {
+        "which": "^1.2.1"
+      }
+    },
+    "node_modules/karma-chrome-launcher/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/karma-mocha": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-2.0.1.tgz",
+      "integrity": "sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.3"
+      }
+    },
+    "node_modules/karma-webpack": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-5.0.0.tgz",
+      "integrity": "sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "webpack-merge": "^4.1.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/karma/node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma/node_modules/chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.1"
+      }
+    },
+    "node_modules/karma/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/karma/node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/karma/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/karma/node_modules/mime": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/karma/node_modules/readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/karma/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/karma/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/karma/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/karma/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/karma/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/karma/node_modules/yargs-parser": {
+      "version": "20.2.7",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+      "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -7059,6 +7725,28 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/log4js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "dev": true,
+      "dependencies": {
+        "date-format": "^3.0.0",
+        "debug": "^4.1.1",
+        "flatted": "^2.0.1",
+        "rfdc": "^1.1.4",
+        "streamroller": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/log4js/node_modules/flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "node_modules/loglevel": {
       "version": "1.7.1",
@@ -7668,6 +8356,15 @@
         "semver": "^5.7.0"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true,
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -8252,6 +8949,12 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -8393,6 +9096,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -8463,6 +9172,69 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.0.0.tgz",
+      "integrity": "sha512-AxHvCb9IWmmP3gMW+epxdj92Gglii+6Z4sb+W+zc2hTTu10HF0yg6hGXot5O74uYkVqG3lfDRLfnRpi6WOwi5A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "4.3.1",
+        "devtools-protocol": "0.0.883894",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "node-fetch": "2.6.1",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.1",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.0.0",
+        "unbzip2-stream": "1.3.3",
+        "ws": "7.4.6"
+      },
+      "engines": {
+        "node": ">=10.18.1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/puppeteer/node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/qjobs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.9"
       }
     },
     "node_modules/qs": {
@@ -8993,6 +9765,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -9608,6 +10386,46 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
+    "node_modules/socket.io": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
+      "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookie": "^0.4.0",
+        "@types/cors": "^2.8.8",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.1",
+        "engine.io": "~4.1.0",
+        "socket.io-adapter": "~2.1.0",
+        "socket.io-parser": "~4.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
+      "dev": true
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "dev": true,
+      "dependencies": {
+        "@types/component-emitter": "^1.2.10",
+        "component-emitter": "~1.3.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
@@ -10026,6 +10844,29 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "node_modules/streamroller": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "dev": true,
+      "dependencies": {
+        "date-format": "^2.1.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/streamroller/node_modules/date-format": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+      "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10186,6 +11027,48 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+      "dev": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/terser": {
@@ -10351,6 +11234,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "node_modules/through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -10377,6 +11266,18 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "dependencies": {
+        "rimraf": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.17.0"
       }
     },
     "node_modules/to-arraybuffer": {
@@ -10575,18 +11476,57 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+    "node_modules/ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
       "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
       "engines": {
-        "node": ">=4.2.0"
+        "node": "*"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "node_modules/unbzip2-stream/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -10871,6 +11811,15 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
+    },
+    "node_modules/void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -11620,6 +12569,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -12090,6 +13048,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   },
@@ -13349,6 +14317,24 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/component-emitter": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+      "integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==",
+      "dev": true
+    },
+    "@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
+      "dev": true
+    },
+    "@types/cors": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
+      "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -13382,6 +14368,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
       "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A==",
       "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.34.0",
@@ -13691,6 +14687,15 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -14045,10 +15050,22 @@
         }
       }
     },
+    "base64-arraybuffer": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+      "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
+      "dev": true
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true
     },
     "batch": {
@@ -14086,6 +15103,40 @@
       "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "blockly": {
@@ -14475,6 +15526,12 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -14897,6 +15954,12 @@
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -14987,6 +16050,35 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.2.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "connect-history-api-fallback": {
@@ -15098,6 +16190,16 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
@@ -15196,6 +16298,12 @@
         }
       }
     },
+    "custom-event": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "dev": true
+    },
     "cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -15227,6 +16335,12 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-3.0.0.tgz",
+      "integrity": "sha512-eyTcpKOcamdhWJXj56DpQMo1ylSQpcGtGKXcU0Tb97+K56/CF5amAqqqNj0+KvA0iw2ynxtHWFsPDSClCxe48w==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.1",
@@ -15379,6 +16493,18 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true
     },
+    "devtools-protocol": {
+      "version": "0.0.883894",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.883894.tgz",
+      "integrity": "sha512-33idhm54QJzf3Q7QofMgCvIVSd2o9H3kQPWaKT/fhoZh+digc+WSiMhbkeG3iN79WY4Hwr9G05NpbhEVrsOYAg==",
+      "dev": true
+    },
+    "di": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+      "dev": true
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -15436,6 +16562,18 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dom-serialize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+      "dev": true,
+      "requires": {
+        "custom-event": "~1.0.0",
+        "ent": "~2.2.0",
+        "extend": "^3.0.0",
+        "void-elements": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -15545,6 +16683,45 @@
         "once": "^1.4.0"
       }
     },
+    "engine.io": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+      "integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~4.0.0",
+        "ws": "~7.4.2"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
+      "integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+      "dev": true,
+      "requires": {
+        "base64-arraybuffer": "0.1.4"
+      }
+    },
     "enhanced-resolve": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
@@ -15576,6 +16753,12 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+      "dev": true
     },
     "errno": {
       "version": "0.1.8",
@@ -16289,6 +17472,29 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -16320,6 +17526,15 @@
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
@@ -16569,6 +17784,12 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -16692,6 +17913,13 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "global-jsdom": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/global-jsdom/-/global-jsdom-8.1.0.tgz",
+      "integrity": "sha512-FBi84GT/MrzP+H3aReBSWXGVz2kdPaDrK/DByKrOq16mRexWrcJNpV6SONCKXWQuzxRjA7UXMfIvxmGyQZS+2Q==",
+      "dev": true,
+      "requires": {}
     },
     "global-modules": {
       "version": "2.0.0",
@@ -17003,6 +18231,16 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dev": true,
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "husky": {
       "version": "6.0.0",
@@ -17393,6 +18631,12 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isbinaryfile": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
+      "integrity": "sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -17584,12 +18828,6 @@
         }
       }
     },
-    "jsdom-global": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
-      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk=",
-      "dev": true
-    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -17667,6 +18905,236 @@
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.1.tgz",
       "integrity": "sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==",
       "dev": true
+    },
+    "karma": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.3.tgz",
+      "integrity": "sha512-JRAujkKWaOtO2LmyPH7K2XXRhrxuFAn9loIL9+iiah6vjz+ZLkqdKsySV9clRITGhj10t9baIfbCl6CJ5hu9gQ==",
+      "dev": true,
+      "requires": {
+        "body-parser": "^1.19.0",
+        "braces": "^3.0.2",
+        "chokidar": "^3.4.2",
+        "colors": "^1.4.0",
+        "connect": "^3.7.0",
+        "di": "^0.0.1",
+        "dom-serialize": "^2.2.1",
+        "glob": "^7.1.6",
+        "graceful-fs": "^4.2.4",
+        "http-proxy": "^1.18.1",
+        "isbinaryfile": "^4.0.6",
+        "lodash": "^4.17.19",
+        "log4js": "^6.2.1",
+        "mime": "^2.4.5",
+        "minimatch": "^3.0.4",
+        "qjobs": "^1.2.0",
+        "range-parser": "^1.2.1",
+        "rimraf": "^3.0.2",
+        "socket.io": "^3.1.0",
+        "source-map": "^0.6.1",
+        "tmp": "0.2.1",
+        "ua-parser-js": "^0.7.23",
+        "yargs": "^16.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+          "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.3.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.7",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
+          "dev": true
+        }
+      }
+    },
+    "karma-chai": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/karma-chai/-/karma-chai-0.1.0.tgz",
+      "integrity": "sha1-vuWtQEAFF4Ea40u5RfdikJEIt5o=",
+      "dev": true,
+      "requires": {}
+    },
+    "karma-chrome-launcher": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
+      "integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
+      "dev": true,
+      "requires": {
+        "which": "^1.2.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "karma-mocha": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/karma-mocha/-/karma-mocha-2.0.1.tgz",
+      "integrity": "sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.3"
+      }
+    },
+    "karma-webpack": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-5.0.0.tgz",
+      "integrity": "sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "webpack-merge": "^4.1.5"
+      }
     },
     "killable": {
       "version": "1.0.1",
@@ -17794,6 +19262,27 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
+        }
+      }
+    },
+    "log4js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.3.0.tgz",
+      "integrity": "sha512-Mc8jNuSFImQUIateBFwdOQcmC6Q5maU0VVvdC2R6XMb66/VnT+7WS4D/0EeNMZu1YODmJe5NIn2XftCzEocUgw==",
+      "dev": true,
+      "requires": {
+        "date-format": "^3.0.0",
+        "debug": "^4.1.1",
+        "flatted": "^2.0.1",
+        "rfdc": "^1.1.4",
+        "streamroller": "^2.2.4"
+      },
+      "dependencies": {
+        "flatted": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+          "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+          "dev": true
         }
       }
     },
@@ -18305,6 +19794,12 @@
         "semver": "^5.7.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -18777,6 +20272,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -18887,6 +20388,12 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -18958,6 +20465,47 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "puppeteer": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-10.0.0.tgz",
+      "integrity": "sha512-AxHvCb9IWmmP3gMW+epxdj92Gglii+6Z4sb+W+zc2hTTu10HF0yg6hGXot5O74uYkVqG3lfDRLfnRpi6WOwi5A==",
+      "dev": true,
+      "requires": {
+        "debug": "4.3.1",
+        "devtools-protocol": "0.0.883894",
+        "extract-zip": "2.0.1",
+        "https-proxy-agent": "5.0.0",
+        "node-fetch": "2.6.1",
+        "pkg-dir": "4.2.0",
+        "progress": "2.0.1",
+        "proxy-from-env": "1.1.0",
+        "rimraf": "3.0.2",
+        "tar-fs": "2.0.0",
+        "unbzip2-stream": "1.3.3",
+        "ws": "7.4.6"
+      },
+      "dependencies": {
+        "progress": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+          "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+          "dev": true
+        },
+        "ws": {
+          "version": "7.4.6",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "dev": true,
+          "requires": {}
+        }
+      }
+    },
+    "qjobs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
       "dev": true
     },
     "qs": {
@@ -19386,6 +20934,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
     },
     "rimraf": {
@@ -19909,6 +21463,40 @@
         }
       }
     },
+    "socket.io": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
+      "integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
+      "dev": true,
+      "requires": {
+        "@types/cookie": "^0.4.0",
+        "@types/cors": "^2.8.8",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.1",
+        "engine.io": "~4.1.0",
+        "socket.io-adapter": "~2.1.0",
+        "socket.io-parser": "~4.0.3"
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+      "integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
+      "dev": true
+    },
+    "socket.io-parser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
+      "integrity": "sha512-t+b0SS+IxG7Rxzda2EVvyBZbvFPBCjJoyHuE0P//7OAsN23GItzDRdWa6ALxZI/8R5ygK7jAR6t028/z+7295g==",
+      "dev": true,
+      "requires": {
+        "@types/component-emitter": "^1.2.10",
+        "component-emitter": "~1.3.0",
+        "debug": "~4.3.1"
+      }
+    },
     "sockjs": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
@@ -20270,6 +21858,25 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "streamroller": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
+      "dev": true,
+      "requires": {
+        "date-format": "^2.1.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.1.0"
+      },
+      "dependencies": {
+        "date-format": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+          "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+          "dev": true
+        }
+      }
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -20393,6 +22000,44 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
+    },
+    "tar-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "terser": {
       "version": "4.8.0",
@@ -20519,6 +22164,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
@@ -20542,6 +22193,15 @@
       "dev": true,
       "requires": {
         "setimmediate": "^1.0.4"
+      }
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^3.0.0"
       }
     },
     "to-arraybuffer": {
@@ -20697,12 +22357,33 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
-    "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+    "ua-parser-js": {
+      "version": "0.7.28",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
+      "dev": true
+    },
+    "unbzip2-stream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
       "dev": true,
-      "peer": true
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
+        }
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -20939,6 +22620,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
       "dev": true
     },
     "w3c-hr-time": {
@@ -21555,6 +23242,15 @@
         }
       }
     },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -21915,6 +23611,16 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "predeploy": "blockly-scripts predeploy",
     "prepublishOnly": "npm run clean && npm run build",
     "start": "blockly-scripts start",
-    "test": "blockly-scripts test",
+    "test:server": "karma start --browsers ChromeHeadless karma.conf.js",
+    "test:run": "karma run",
+    "test": "karma start --single-run --browsers ChromeHeadless karma.conf.js",
     "prepare": "husky install"
   },
   "main": "./dist/index.js",
@@ -42,13 +44,21 @@
   "devDependencies": {
     "@blockly/dev-scripts": "^1.2.6",
     "@blockly/dev-tools": "^2.3.0",
+    "@sinonjs/fake-timers": "^6.0.1",
     "blockly": "^5.20210325.0",
     "chai": "^4.2.0",
+    "global-jsdom": "^8.1.0",
     "husky": "^6.0.0",
     "jsdom": "^16.4.0",
-    "jsdom-global": "^3.0.2",
+    "karma": "^6.3.3",
+    "karma-chai": "^0.1.0",
+    "karma-chrome-launcher": "^3.1.0",
+    "karma-mocha": "^2.0.1",
+    "karma-webpack": "^5.0.0",
     "mocha": "^7.1.0",
-    "sinon": "^9.0.1"
+    "puppeteer": "^10.0.0",
+    "sinon": "^9.0.1",
+    "webpack": "^4.46.0"
   },
   "peerDependencies": {
     "blockly": ">=5.20210325.0"

--- a/src/gamepad.js
+++ b/src/gamepad.js
@@ -1,0 +1,267 @@
+/**
+ * @fileoverview All of the types necessary to work with gamepads.
+ */
+
+/**
+ * The buttons available on a universal gamepad.
+ * @enum {string}
+ */
+export const GamepadButton = {
+  CROSS: 'cross',
+  CIRCLE: 'circle',
+  SQUARE: 'square',
+  TRIANGLE: 'triangle',
+  L1: 'l1',
+  R1: 'r1',
+  L2: 'l2',
+  R2: 'r2',
+  SELECT: 'select',
+  START: 'start',
+  LEFT_STICK: 'left_stick',
+  RIGHT_STICK: 'right_stick',
+  UP: 'up',
+  DOWN: 'down',
+  LEFT: 'left',
+  RIGHT: 'right',
+};
+
+/**
+ * All possible buttons.
+ * @type {!Set<GamepadButton>}
+ */
+export const ALL_BUTTONS = new Set(Object.values(GamepadButton));
+
+/**
+ * @type {Map<GamepadButton, number>}
+ */
+export const GAMEPAD_BUTTON_TO_INDEX = new Map([
+  [GamepadButton.CROSS, 0],
+  [GamepadButton.CIRCLE, 1],
+  [GamepadButton.SQUARE, 2],
+  [GamepadButton.TRIANGLE, 3],
+  [GamepadButton.L1, 4],
+  [GamepadButton.R1, 5],
+  [GamepadButton.L2, 6],
+  [GamepadButton.R2, 7],
+  [GamepadButton.SELECT, 8],
+  [GamepadButton.START, 9],
+  [GamepadButton.LEFT_STICK, 10],
+  [GamepadButton.RIGHT_STICK, 11],
+  [GamepadButton.UP, 12],
+  [GamepadButton.DOWN, 13],
+  [GamepadButton.LEFT, 14],
+  [GamepadButton.RIGHT, 15],
+]);
+
+/**
+ * The axes available on a universal gamepad.
+ * @enum {string}
+ */
+export const GamepadAxis = {
+  LEFT_HORIZONTAL_LEFT: 'left_horizontal_left',
+  LEFT_HORIZONTAL_RIGHT: 'left_horizontal_right',
+  LEFT_VERTICAL_UP: 'left_vertical_up',
+  LEFT_VERTICAL_DOWN: 'left_vertical_down',
+  RIGHT_HORIZONTAL_LEFT: 'right_horizontal_left',
+  RIGHT_HORIZONTAL_RIGHT: 'right_horizontal_right',
+  RIGHT_VERTICAL_UP: 'right_vertical_up',
+  RIGHT_VERTICAL_DOWN: 'right_vertical_down',
+};
+
+/**
+ * All possible axes.
+ * @type {!Set<GamepadAxis>}
+ */
+export const ALL_AXES = new Set(Object.values(GamepadAxis));
+
+/**
+ * @type {Map<GamepadAxis, number>}
+ */
+export const GAMEPAD_AXIS_TO_INDEX = new Map([
+  [GamepadAxis.LEFT_HORIZONTAL_LEFT, 0],
+  [GamepadAxis.LEFT_HORIZONTAL_RIGHT, 0],
+  [GamepadAxis.LEFT_VERTICAL_UP, 1],
+  [GamepadAxis.LEFT_VERTICAL_DOWN, 1],
+  [GamepadAxis.RIGHT_HORIZONTAL_LEFT, 2],
+  [GamepadAxis.RIGHT_HORIZONTAL_RIGHT, 2],
+  [GamepadAxis.RIGHT_VERTICAL_UP, 3],
+  [GamepadAxis.RIGHT_VERTICAL_DOWN, 3],
+]);
+
+/**
+ * Defines a combination of buttons or axes used to trigger an action.
+ */
+export class GamepadCombination {
+  /**
+   * Constructs a combination.
+   * @param {Set<GamepadButton|GamepadAxis>=} optCombination Optionally
+   *     initialize the sequence with this combination of buttons and axes.
+   */
+  constructor(optCombination) {
+    /**
+     * The buttons in the order they should be pressed.
+     * @type {!Set<GamepadButton|GamepadAxis>}
+     * @private
+     */
+    this.combination_ = optCombination || new Set();
+  }
+
+  /**
+   * The inverse of the serialize method.
+   * @param {string} serialization The string to deserialize.
+   * @throws {Error} If the serialization is invalid.
+   * @return {!GamepadCombination} The sequence represented by the
+   *     serialization.
+   * @public
+   */
+  static deserialize(serialization) {
+    const sequence = serialization.split('+');
+    for (const buttonOrAxis of sequence) {
+      if (!ALL_BUTTONS.has(buttonOrAxis) && !ALL_AXES.has(buttonOrAxis)) {
+        throw new Error(
+            `Neither a valid button nor an axis ${buttonOrAxis}.`);
+      }
+    }
+    return new GamepadCombination(new Set(sequence.sort()));
+  }
+
+  /**
+   * Create a combination from a single axis.
+   * @param {!GamepadAxis} gamepadAxis The axis to add.
+   * @return {!GamepadCombination} The combination with just the given axis.
+   * @public
+   */
+  static fromSingleAxis(gamepadAxis) {
+    return new GamepadCombination().addAxis(gamepadAxis);
+  }
+
+  /**
+   * Create a combination from a single button.
+   * @param {!GamepadButton} gamepadButton The button to add.
+   * @return {!GamepadCombination} The combination with just the given button.
+   * @public
+   */
+  static fromSingleButton(gamepadButton) {
+    return new GamepadCombination().addButton(gamepadButton);
+  }
+
+  /**
+   * Add a button to the combination.
+   * @param {!GamepadButton} button The button to add.
+   * @return {!GamepadCombination} This instance so you can chain more.
+   * @public
+   */
+  addButton(button) {
+    this.combination_.add(button);
+    return this;
+  }
+
+  /**
+   * Add an axis to the combination.
+   * @param {GamepadAxis} axis The axis to add.
+   * @return {!GamepadCombination} This instance so you can chain more.
+   * @public
+   */
+  addAxis(axis) {
+    this.combination_.add(axis);
+    return this;
+  }
+
+  /**
+   * Serialize this sequence into a string, which can be used as a Map key.
+   * @return {string} The serialization.
+   * @public
+   */
+  serialize() {
+    return Array.from(this.combination_).sort().join('+');
+  }
+
+  /**
+   * Checks whether there are any buttons or axes activated.
+   * @return {boolean} True if there are no buttons or axes activated. False
+   *     otherwise.
+   * @public
+   */
+  isEmpty() {
+    return this.combination_.size === 0;
+  }
+
+  /**
+   * Translate this combination into a Gamepad object.
+   * @return {!Gamepad} A gamepad representing this gamepad combination.
+   * @public
+   */
+  asGamepad() {
+    const buttons = [];
+    for (const [gamepadButton, index] of GAMEPAD_BUTTON_TO_INDEX.entries()) {
+      if (this.combination_.has(gamepadButton)) {
+        buttons[index] = {value: 1.0, pressed: true};
+      } else {
+        buttons[index] = {value: 0.0, pressed: false};
+      }
+    }
+
+    const axes = [];
+    if (this.combination_.has(GamepadAxis.LEFT_HORIZONTAL_LEFT)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.LEFT_HORIZONTAL_LEFT)] = -1.0;
+    }
+    if (this.combination_.has(GamepadAxis.LEFT_HORIZONTAL_RIGHT)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.LEFT_HORIZONTAL_RIGHT)] = 1.0;
+    }
+    if (this.combination_.has(GamepadAxis.LEFT_VERTICAL_UP)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.LEFT_VERTICAL_UP)] = -1.0;
+    }
+    if (this.combination_.has(GamepadAxis.LEFT_VERTICAL_DOWN)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.LEFT_VERTICAL_DOWN)] = 1.0;
+    }
+    if (this.combination_.has(GamepadAxis.RIGHT_HORIZONTAL_LEFT)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.RIGHT_HORIZONTAL_LEFT)] = -1.0;
+    }
+    if (this.combination_.has(GamepadAxis.RIGHT_HORIZONTAL_RIGHT)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.RIGHT_HORIZONTAL_RIGHT)] = 1.0;
+    }
+    if (this.combination_.has(GamepadAxis.RIGHT_VERTICAL_UP)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.RIGHT_VERTICAL_UP)] = -1.0;
+    }
+    if (this.combination_.has(GamepadAxis.RIGHT_VERTICAL_DOWN)) {
+      axes[GAMEPAD_AXIS_TO_INDEX.get(GamepadAxis.RIGHT_VERTICAL_DOWN)] = 1.0;
+    }
+
+    return {axes, buttons};
+  }
+}
+
+GamepadCombination.LEFT_STICK_UP = GamepadCombination.fromSingleAxis(
+    GamepadAxis.LEFT_VERTICAL_UP);
+GamepadCombination.LEFT_STICK_LEFT = GamepadCombination.fromSingleAxis(
+    GamepadAxis.LEFT_HORIZONTAL_LEFT);
+GamepadCombination.LEFT_STICK_DOWN = GamepadCombination.fromSingleAxis(
+    GamepadAxis.LEFT_VERTICAL_DOWN);
+GamepadCombination.LEFT_STICK_RIGHT = GamepadCombination.fromSingleAxis(
+    GamepadAxis.LEFT_HORIZONTAL_RIGHT);
+
+GamepadCombination.RIGHT_STICK_LEFT = GamepadCombination.fromSingleAxis(
+    GamepadAxis.RIGHT_HORIZONTAL_LEFT);
+GamepadCombination.RIGHT_STICK_RIGHT = GamepadCombination.fromSingleAxis(
+    GamepadAxis.RIGHT_HORIZONTAL_RIGHT);
+GamepadCombination.RIGHT_STICK_UP = GamepadCombination.fromSingleAxis(
+    GamepadAxis.RIGHT_VERTICAL_UP);
+GamepadCombination.RIGHT_STICK_DOWN = GamepadCombination.fromSingleAxis(
+    GamepadAxis.RIGHT_VERTICAL_DOWN);
+
+GamepadCombination.TRIANGLE = GamepadCombination.fromSingleButton(
+    GamepadButton.TRIANGLE);
+GamepadCombination.CROSS = GamepadCombination.fromSingleButton(
+    GamepadButton.CROSS);
+GamepadCombination.CIRCLE = GamepadCombination.fromSingleButton(
+    GamepadButton.CIRCLE);
+GamepadCombination.SQUARE = GamepadCombination.fromSingleButton(
+    GamepadButton.SQUARE);
+
+GamepadCombination.UP = GamepadCombination.fromSingleButton(GamepadButton.UP);
+GamepadCombination.DOWN = GamepadCombination.fromSingleButton(
+    GamepadButton.DOWN);
+GamepadCombination.LEFT = GamepadCombination.fromSingleButton(
+    GamepadButton.LEFT);
+GamepadCombination.RIGHT = GamepadCombination.fromSingleButton(
+    GamepadButton.RIGHT);

--- a/src/gamepad_monitor.js
+++ b/src/gamepad_monitor.js
@@ -1,0 +1,272 @@
+/**
+ * @fileoverview Everything needed to monitors the state of the gamepad.
+ */
+
+import Blockly from 'blockly';
+import {
+  GamepadAxis,
+  GAMEPAD_AXIS_TO_INDEX,
+  GAMEPAD_BUTTON_TO_INDEX,
+  GamepadCombination} from './gamepad';
+import {GamepadShortcutRegistry} from './gamepad_shortcut_registry';
+
+const DEFAULT_DELAY_BETWEEN_COMBINATIONS_MILLISECONDS = 100;
+const DEFAULT_AXIS_ACTIVATION_THRESHOLD = 0.4;
+
+/**
+ * Monitors the connected gamepads, and listens for events.
+ */
+export class GamepadMonitor {
+  /**
+   * Constructs a gamepad monitor.
+   * @param {GamepadShortcutRegistry=} optShortcutRegistry The shortcut
+   *     registry to trigger when buttons or axes are activated.
+   * @param {number=} optDelayBetweenCombinations The delay between when each
+   *     button combination is handled in milliseconds.
+   * @param {number=} optAxisActivationThreshold The degree, on a scale of 0.0
+   *     to 1.0, of when an axis can be considered as activated.
+   */
+  constructor(optShortcutRegistry, optDelayBetweenCombinations,
+      optAxisActivationThreshold) {
+    /**
+     * The shortcut registry that will be triggered when buttons or axes are
+     * activated.
+     * @type {!GamepadShortcutRegistry}
+     * @private
+     */
+    this.registry_ = optShortcutRegistry || new GamepadShortcutRegistry();
+
+    /**
+     * The indexes of all currently connected gamepads.
+     * @type {!Set<number>}
+     * @private
+     */
+    this.connectedGamepadIndexes_ = new Set();
+
+    /**
+     * The delay between when each button combination is handled in
+     * milliseconds.
+     * @type {number}
+     * @private
+     */
+    this.delayBetweenCombinations_ = optDelayBetweenCombinations ||
+      DEFAULT_DELAY_BETWEEN_COMBINATIONS_MILLISECONDS;
+
+    /**
+     * The amount that an axis should be moved in either direction before it is
+     * considered activated, on a scale of 0.0 to 1.0.
+     * @type {number}
+     * @private
+     */
+    this.axisActivationThreshold_ = optAxisActivationThreshold ||
+      DEFAULT_AXIS_ACTIVATION_THRESHOLD;
+
+    /**
+     * The time since the last command was handled by the monitor. This is to
+     * be used in conjunction with delayBetweenCombinations_ to ensure that
+     * commands are not handled too frequently.
+     * @type {number}
+     * @private
+     */
+    this.timeSinceLastCommandHandled_ = Number.NEGATIVE_INFINITY;
+
+    /**
+     * The workspaces that we are monitoring input for.
+     * @type {!Array<Blockly.WorkspaceSvg>}
+     * @private
+     */
+    this.workspaces_ = [];
+
+    /**
+     * Handle a gamepadconnected event.
+     * @type {function(GamepadEvent):void}
+     * @private
+     */
+    this.gamepadConnectedHandler_ = this.handleGamepadConnected_.bind(this);
+
+    /**
+     * Handle a gamepaddisonnected event.
+     * @type {function(GamepadEvent):void}
+     * @private
+     */
+    this.gamepadDisconnectedHandler_ =
+        this.handleGamepadDisconnected_.bind(this);
+
+    /**
+     * Whether this monitor has been disposed.
+     * @type {boolean}
+     * @private
+     */
+    this.disposed_ = false;
+  }
+
+  /**
+   * Add necessary event listeners.
+   * @public
+   */
+  init() {
+    addEventListener('gamepadconnected', this.gamepadConnectedHandler_);
+    addEventListener('gamepaddisconnected',
+        this.gamepadDisconnectedHandler_);
+    requestAnimationFrame(
+        (timestamp) => this.handleAnimationFrame_(timestamp));
+  }
+
+  /**
+   * Dispose all event listeners.
+   * @public
+   */
+  dispose() {
+    removeEventListener('gamepadconnected',
+        this.gamepadConnectedHandler_);
+    removeEventListener('gamepaddisconnected',
+        this.gamepadDisconnectedHandler_);
+    this.disposed_ = true;
+  }
+
+  /**
+   * Handle a gamepadconnected event.
+   * @param {GamepadEvent} event The event to handle.
+   * @private
+   */
+  handleGamepadConnected_(event) {
+    this.connectedGamepadIndexes_.add(event.gamepad.index);
+  }
+
+  /**
+   * Handle a gamepaddisconnected event.
+   * @param {GamepadEvent} event The event to handle.
+   * @private
+   */
+  handleGamepadDisconnected_(event) {
+    this.connectedGamepadIndexes_.delete(event.gamepad.index);
+  }
+
+  /**
+   * Make sure that changes are sent to the given workspace.
+   * @param {!Blockly.WorkspaceSvg} workspace A workspace to monitor input for.
+   * @public
+   */
+  addWorkspace(workspace) {
+    this.workspaces_.push(workspace);
+  }
+
+  /**
+   * Removes the given workspace from any future updates.
+   * @param {!Blockly.WorkspaceSvg} workspace The workspace to remove.
+   * @public
+   */
+  removeWorkspace(workspace) {
+    const workspaceIdx = this.workspaces_.indexOf(workspace);
+    if (workspaceIdx > -1) {
+      this.workspaces_.splice(workspaceIdx, 1);
+    }
+  }
+
+  /**
+   * Handle input from the gamepad during an animation frame.
+   * TODO(pkukkapalli): change to wait for the button to be held a certain
+   * amount of time, instead of delaying between inputs?
+   * @param {number} timestamp The timestamp of this animation frame.
+   * @private
+   */
+  handleAnimationFrame_(timestamp) {
+    if (this.disposed_) {
+      return;
+    }
+
+    if (this.connectedGamepadIndexes_.size === 0) {
+      requestAnimationFrame(
+          (timestamp) => this.handleAnimationFrame_(timestamp));
+      return;
+    }
+
+    const elapsedTime =
+        Math.floor(timestamp) - this.timeSinceLastCommandHandled_;
+    if (elapsedTime <= DEFAULT_DELAY_BETWEEN_COMBINATIONS_MILLISECONDS) {
+      requestAnimationFrame(
+          (timestamp) => this.handleAnimationFrame_(timestamp));
+      return;
+    }
+
+    for (const gamepad of navigator.getGamepads()) {
+      const combination = this.currentCombination_(gamepad);
+      for (const workspace of this.workspaces_) {
+        this.registry_.onActivate(workspace, combination);
+      }
+    }
+
+    requestAnimationFrame(
+        (timestamp) => this.handleAnimationFrame_(timestamp));
+  }
+
+  /**
+   * Get the current combination entered on the given gamepad, if there is any.
+   * @param {Gamepad} gamepad The gamepad to examine.
+   * @return {GamepadCombination} The combination currently entered by the
+   *     gamepad.
+   * @private
+   */
+  currentCombination_(gamepad) {
+    const combination = new GamepadCombination();
+
+    for (const [gamepadButton, index] of GAMEPAD_BUTTON_TO_INDEX.entries()) {
+      if (gamepad.buttons[index].pressed) {
+        combination.addButton(gamepadButton);
+      }
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.LEFT_HORIZONTAL_LEFT) <
+        -this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.LEFT_HORIZONTAL_LEFT);
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.LEFT_HORIZONTAL_RIGHT) >
+        this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.LEFT_HORIZONTAL_RIGHT);
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.LEFT_VERTICAL_UP) <
+        -this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.LEFT_VERTICAL_UP);
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.LEFT_VERTICAL_DOWN) >
+        this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.LEFT_VERTICAL_DOWN);
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.RIGHT_HORIZONTAL_LEFT) <
+        -this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.RIGHT_HORIZONTAL_LEFT);
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.RIGHT_HORIZONTAL_RIGHT) >
+        this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.RIGHT_HORIZONTAL_RIGHT);
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.RIGHT_VERTICAL_UP) <
+        -this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.RIGHT_VERTICAL_UP);
+    }
+
+    if (this.getAxisValue_(gamepad, GamepadAxis.RIGHT_VERTICAL_DOWN) >
+        this.axisActivationThreshold_) {
+      combination.addAxis(GamepadAxis.RIGHT_VERTICAL_DOWN);
+    }
+
+    return combination;
+  }
+
+  /**
+   * Get the value of the given axis.
+   * @param {Gamepad} gamepad The gamepad to examine.
+   * @param {GamepadAxis} gamepadAxis The axis to check for.
+   * @return {number} The value of the axis on a scale of -1 to 1.
+   * @private
+   */
+  getAxisValue_(gamepad, gamepadAxis) {
+    return gamepad.axes[GAMEPAD_AXIS_TO_INDEX.get(gamepadAxis)];
+  }
+}

--- a/src/gamepad_shortcut_registry.js
+++ b/src/gamepad_shortcut_registry.js
@@ -1,0 +1,265 @@
+/**
+ * @fileoverview Holds all of the shortcuts for gamepad accessibility.
+ */
+
+import * as Blockly from 'blockly/core';
+import cloneDeep from 'lodash.clonedeep';
+import {GamepadCombination} from './gamepad';
+
+/**
+ * Class for the registry of gamepad shortcuts. This is intended to be a
+ * singleton. You should not create a new instance, and only access this class
+ * from gamepadShortcutRegistry.
+ */
+export class GamepadShortcutRegistry {
+  /**
+   * Constructs a shortcut registry.
+   */
+  constructor() {
+    /**
+     * Registry of all gamepad shortcuts, keyed by name of shortcut.
+     * @type {!Map<string, GamepadShortcut>}
+     * @private
+     */
+    this.registry_ = new Map();
+
+    /**
+     * Map of button combinations to a set of shortcut names.
+     * @type {!Map<string, Set<string>>}
+     * @private
+     */
+    this.combinationMap_ = new Map();
+  }
+
+  /**
+   * Registers a gamepad shortcut.
+   * @param {!GamepadShortcut} shortcut The shortcut
+   *     for this button code.
+   * @param {boolean=} optAllowOverrides True to prevent a warning when
+   *     overriding an already registered item.
+   * @throws {Error} If a shortcut with the same name already exists.
+   * @public
+   */
+  register(shortcut, optAllowOverrides) {
+    if (this.registry_.has(shortcut.name) && !optAllowOverrides) {
+      throw new Error(`Shortcut with name ${shortcut.name} already exists.`);
+    }
+    this.registry_.set(shortcut.name, shortcut);
+  }
+
+  /**
+   * Unregisters a gamepad shortcut registered with the given button code. This
+   * will also remove any button mappings that reference this shortcut.
+   * @param {string} shortcutName The name of the shortcut to unregister.
+   * @return {boolean} True if an item was unregistered, false otherwise.
+   * @public
+   */
+  unregister(shortcutName) {
+    if (!this.registry_.has(shortcutName)) {
+      console.warn(`Gamepad shortcut with name ${shortcutName} not found.`);
+      return false;
+    }
+
+    this.removeAllCombinationMappings(shortcutName);
+
+    this.registry_.delete(shortcutName);
+    return true;
+  }
+
+  /**
+   * Adds a mapping between a button combination and a shortcut.
+   * @param {!GamepadCombination} combination The gamepad combination for the
+   *     shortcut.
+   * @param {string} shortcutName The name of the shortcut to execute when the
+   *     given combination is activated.
+   * @param {boolean=} optAllowCollision True to prevent an error when adding a
+   *     shortcut to a combination that is already mapped to a shortcut.
+   * @throws {Error} If the given combination is already mapped a shortcut.
+   * @public
+   */
+  addCombinationMapping(combination, shortcutName, optAllowCollision) {
+    const serializedCombination = combination.serialize();
+    if (this.combinationMap_.has(serializedCombination) && !optAllowCollision) {
+      throw new Error(
+          `Shortcut with name ${shortcutName} collides with shortcuts 
+          ${this.combinationMap_.get(serializedCombination)}`);
+    } else if (this.combinationMap_.has(serializedCombination) &&
+               optAllowCollision) {
+      this.combinationMap_.get(serializedCombination).add(shortcutName);
+    } else {
+      this.combinationMap_.set(serializedCombination, new Set([shortcutName]));
+    }
+  }
+
+  /**
+   * Removes a mapping between a button combination and a shortcut.
+   * @param {!GamepadCombination} combination The gamepad combination for the
+   *     shortcut.
+   * @param {string} shortcutName The name of the shortcut to execute when the
+   *     given combination is activated.
+   * @param {boolean=} optQuiet True to not console warn when there is no
+   *     shortcut to remove.
+   * @return {boolean} True if a mapping was removed, false otherwise.
+   * @public
+   */
+  removeCombinationMapping(combination, shortcutName, optQuiet) {
+    const serializedCombination = combination.serialize();
+    if (!this.combinationMap_.has(serializedCombination)) {
+      if (!optQuiet) {
+        console.warn(
+            `No gamepad shortcut with name ${shortcutName}
+            registered with combination ${serializedCombination}`);
+      }
+      return false;
+    }
+
+    const shortcutNames = this.combinationMap_.get(serializedCombination);
+    if (shortcutNames.size === 0) {
+      this.combinationMap_.delete(serializedCombination);
+      if (!optQuiet) {
+        console.warn(
+            `No gamepad shortcut with name ${shortcutName}
+            registered with combination ${serializedCombination}`);
+      }
+      return false;
+    }
+
+    if (!shortcutNames.has(serializedCombination)) {
+      if (!optQuiet) {
+        console.warn(
+            `No gamepad shortcut with name ${shortcutName}
+            registered with combination ${serializedCombination}`);
+      }
+      return false;
+    }
+
+    shortcutNames.delete(shortcutName);
+    if (shortcutNames.size === 0) {
+      this.combinationMap_.delete(serializedCombination);
+    }
+    return true;
+  }
+
+  /**
+   * Removes all the combination mappings for a shortcut with the given name.
+   * Useful when changing the default mappings and the combinations registered
+   * to the shortcut are unknown.
+   * @param {string} shortcutName The name of the shortcut to remove from the
+   *     map.
+   * @public
+   */
+  removeAllCombinationMappings(shortcutName) {
+    for (const serializedCombination of this.combinationMap_.keys()) {
+      this.removeCombinationMapping(
+          GamepadCombination.deserialize(serializedCombination),
+          shortcutName, /* optQuiet= */ true);
+    }
+  }
+
+  /**
+   * Sets the combination map. Setting the combination map will override any
+   * default combination mappings.
+   * @param {!Map<string, Set<string>>} combinationMap The map with combination
+   *     to shortcut names.
+   * @public
+   */
+  setCombinationMap(combinationMap) {
+    this.combinationMap_ = combinationMap;
+  }
+
+  /**
+   * Gets the current combination map.
+   * @return {!Map<string, Set<string>>} The map holding combinations to
+   *     shortcut names.
+   */
+  getCombinationMap() {
+    return cloneDeep(this.combinationMap_);
+  }
+
+  /**
+   * Gets the registry of gamepad shortcuts.
+   * @return {!Map<string, !GamepadShortcut>} The
+   *     registry of gamepad shortcuts.
+   * @public
+   */
+  getRegistry() {
+    return cloneDeep(this.registry_);
+  }
+
+  /**
+   * Handles gamepad buttons and axes being activated.
+   * @param {!Blockly.Workspace} workspace The active workspace to apply the
+   *     operation to.
+   * @param {!GamepadCombination} combination The combination pressed.
+   * @return {boolean} True if the combination was handled, false otherwise.
+   * @public
+   */
+  onActivate(workspace, combination) {
+    if (combination.isEmpty()) {
+      return false;
+    }
+
+    const shortcutNames = this.getShortcutNamesByCombination(combination);
+    for (const shortcutName of shortcutNames) {
+      if (!this.registry_.has(shortcutName)) {
+        console.warn(`Invalid shortcut name used ${shortcutName}.`);
+        continue;
+      }
+      const shortcut = this.registry_.get(shortcutName);
+      if (shortcut.preconditionFn && !shortcut.preconditionFn(workspace)) {
+        continue;
+      }
+      // If the combination has been handled, stop processing shortcuts.
+      if (shortcut.callback &&
+        shortcut.callback(workspace, combination, shortcut)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Gets the shortcuts registered to the given combination.
+   * @param {!GamepadCombination} combination The combination to look up.
+   * @return {!Array<string>} The set of shortcuts to call when the given
+   *     combination is used.
+   * @public
+   */
+  getShortcutNamesByCombination(combination) {
+    if (!this.combinationMap_.has(combination.serialize())) {
+      return [];
+    }
+    return Array.from(this.combinationMap_.get(combination.serialize()));
+  }
+
+  /**
+   * Gets the combinations that the shortcut with the given name is registered
+   * under.
+   * @param {string} shortcutName The name of the shortcut.
+   * @return {!Array<string>} A set of all the combinations the shortcut is
+   *     registered under.
+   */
+  getCombinationsByShortcutName(shortcutName) {
+    const combinations = [];
+    for (const [serializedCombination, shortcutNames] of
+      this.combinationMap_.entries()) {
+      const combination = GamepadCombination.deserialize(serializedCombination);
+      if (shortcutNames.has(shortcutName)) {
+        combinations.push(combination);
+      }
+    }
+    return combinations;
+  }
+}
+
+/**
+ * A gamepad shortcut.
+ * @typedef {{
+ *    callback: ((function(!Blockly.Workspace, GamepadCombination,
+ * GamepadShortcut):boolean)|undefined),
+ *    name: string,
+ *    preconditionFn: ((function(!Blockly.Workspace):boolean)|undefined),
+ *    metadata: (Object|undefined)
+ * }}
+ */
+export const GamepadShortcut = {};

--- a/src/gesture_monkey_patch.js
+++ b/src/gesture_monkey_patch.js
@@ -14,7 +14,7 @@
  */
 
 import * as Blockly from 'blockly/core';
-import {accessbilityStatus} from './accessibility_status';
+import {accessibilityStatus} from './accessibility_status';
 
 
 const oldDoWorkspaceClick = Blockly.Gesture.prototype.doWorkspaceClick_;
@@ -29,7 +29,7 @@ const oldDoWorkspaceClick = Blockly.Gesture.prototype.doWorkspaceClick_;
 Blockly.Gesture.prototype.doWorkspaceClick_ = function(e) {
   oldDoWorkspaceClick.call(this, e);
   const ws = this.creatorWorkspace_;
-  if (e.shiftKey && accessbilityStatus.isGamepadAccessibilityEnabled(ws)) {
+  if (e.shiftKey && accessibilityStatus.isGamepadAccessibilityEnabled(ws)) {
     const screenCoord = new Blockly.utils.Coordinate(e.clientX, e.clientY);
     const wsCoord = Blockly.utils.screenToWsCoordinates(ws, screenCoord);
     const wsNode = Blockly.ASTNode.createWorkspaceNode(ws, wsCoord);
@@ -48,7 +48,7 @@ const oldDoBlockClick = Blockly.Gesture.prototype.doBlockClick_;
 Blockly.Gesture.prototype.doBlockClick_ = function(e) {
   oldDoBlockClick.call(this, e);
   if (!this.targetBlock_.isInFlyout && this.mostRecentEvent_.shiftKey &&
-      accessbilityStatus.isGamepadAccessibilityEnabled(
+      accessibilityStatus.isGamepadAccessibilityEnabled(
           this.targetBlock_.workspace)) {
     this.creatorWorkspace_.getCursor().setCurNode(
         Blockly.ASTNode.createTopNode(this.targetBlock_));

--- a/src/index.js
+++ b/src/index.js
@@ -12,11 +12,13 @@ import {
 import {LineCursor, pluginInfo as LineCursorPluginInfo} from './line_cursor';
 import {Navigation} from './navigation';
 import {NavigationController} from './navigation_controller';
+import {GamepadMonitor} from './gamepad_monitor';
 
 export {
   Constants,
   FlyoutCursor,
   FlyoutCursorPluginInfo,
+  GamepadMonitor,
   LineCursor,
   LineCursorPluginInfo,
   Navigation,

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -149,7 +149,7 @@ export class Navigation {
    * Sets the state for the given workspace.
    * @param {!Blockly.WorkspaceSvg} workspace The workspace to set the state on.
    * @param {!Constants.STATE} state The navigation state.
-   * @protected
+   * @public
    */
   setState(workspace, state) {
     this.workspaceStates[workspace.id] = state;

--- a/test/index.html
+++ b/test/index.html
@@ -20,7 +20,7 @@
   The cursor controls how the user navigates the blocks, inputs, fields and connections on a workspace.
   This demo shows three different cursors:<br />
   <b>Default Cursor:</b> This cursor uses previous, next, in, and out to navigate through the different
-  parts of a block. See the <a href="https://developers.google.com/blockly/guides/configure/web/keyboard-nav">developer documentation</a> for more information. <br />
+  parts of a block. Instructions coming soon.
   <b>Basic Cursor:</b> Uses pre order traversal to allow users to navigate
   through everything using only the previous and next command.<br />
   <b>Line Cursor:</b> We tried to make this cursor mimic a text editor. Navigating

--- a/test/navigation_modify_test.mocha.js
+++ b/test/navigation_modify_test.mocha.js
@@ -5,7 +5,6 @@
  */
 
 import chai from 'chai';
-// const Blockly = require('blockly/node');
 import Blockly from 'blockly';
 import {Navigation} from '../src/navigation';
 import {testHelpers} from '@blockly/dev-tools';

--- a/test/navigation_modify_test.mocha.js
+++ b/test/navigation_modify_test.mocha.js
@@ -4,11 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const chai = require('chai');
-const Blockly = require('blockly/node');
-const {Navigation} = require('../src/navigation');
+import chai from 'chai';
+// const Blockly = require('blockly/node');
+import Blockly from 'blockly';
+import {Navigation} from '../src/navigation';
+import {testHelpers} from '@blockly/dev-tools';
+import {createBlocklyDiv} from './test_helper';
+
 const assert = chai.assert;
-const {testHelpers} = require('@blockly/dev-tools');
 const {captureWarnings} = testHelpers;
 
 suite('Insert/Modify', function() {
@@ -71,8 +74,7 @@ suite('Insert/Modify', function() {
   }
 
   setup(function() {
-    this.jsdomCleanup =
-        require('jsdom-global')('<!DOCTYPE html><div id="blocklyDiv"></div>');
+    createBlocklyDiv('blocklyDiv');
     // NOTE: block positions chosen such that they aren't unintentionally
     // bumped out of bounds during tests.
     const xmlText = `<xml xmlns="https://developers.google.com/blockly/xml">
@@ -115,7 +117,6 @@ suite('Insert/Modify', function() {
     delete Blockly.Blocks['stack_block'];
     delete Blockly.Blocks['row_block'];
     delete Blockly.Blocks['statement_block'];
-    this.jsdomCleanup();
   });
 
   suite('Marked Connection', function() {

--- a/test/navigation_test.mocha.js
+++ b/test/navigation_test.mocha.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2020 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 
@@ -5,7 +11,6 @@ import chai from 'chai';
 import sinon from 'sinon';
 import FakeTimers from '@sinonjs/fake-timers';
 
-// const Blockly = require('blockly/node');
 import Blockly from 'blockly';
 import {NavigationController, Navigation, GamepadMonitor, Constants}
   from '../src/index';

--- a/test/shortcuts_test.mocha.js
+++ b/test/shortcuts_test.mocha.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 'use strict';
 
 import sinon from 'sinon';

--- a/test/shortcuts_test.mocha.js
+++ b/test/shortcuts_test.mocha.js
@@ -1,29 +1,35 @@
-/**
- * @license
- * Copyright 2021 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
+'use strict';
 
-const sinon = require('sinon');
+import sinon from 'sinon';
+import FakeTimers from '@sinonjs/fake-timers';
 
-const Blockly = require('blockly/node');
+import Blockly from 'blockly';
 
-const {NavigationController} = require('../src/index');
-const {createNavigationWorkspace, createKeyDownEvent} =
-    require('./test_helper');
+import {NavigationController, Navigation, GamepadMonitor}
+  from '../src/index';
+import {
+  connectFakeGamepad,
+  createBlocklyDiv,
+  createNavigationWorkspace,
+  createNavigatorGetGamepadsStub,
+  disconnectFakeGamepad}
+  from './test_helper';
+import {GamepadCombination} from '../src/gamepad';
+import {GamepadShortcutRegistry} from '../src/gamepad_shortcut_registry';
 
 suite('Shortcut Tests', function() {
   /**
-   * Creates a test for not running keyDown events when the workspace is in read
+   * Creates a test for not running gamepad input when the workspace is in read
    * only mode.
    * @param {string} testCaseName The name of the test case.
-   * @param {Object} keyEvent Mocked key down event. Use createKeyDownEvent.
+   * @param {GamepadCombination} gamepadCombination Gamepad combination to try.
    */
-  function runReadOnlyTest(testCaseName, keyEvent) {
+  function runReadOnlyTest(testCaseName, gamepadCombination) {
     test(testCaseName, function() {
       this.workspace.options.readOnly = true;
       const hideChaffSpy = sinon.spy(Blockly, 'hideChaff');
-      Blockly.onKeyDown(keyEvent);
+      createNavigatorGetGamepadsStub(gamepadCombination);
+      this.clock.runToFrame();
       sinon.assert.notCalled(hideChaffSpy);
     });
   }
@@ -31,12 +37,13 @@ suite('Shortcut Tests', function() {
   /**
    * Creates a test for not runnin a shortcut when a gesture is in progress.
    * @param {string} testCaseName The name of the test case.
-   * @param {Object} keyEvent Mocked key down event. Use createKeyDownEvent.
+   * @param {GamepadCombination} gamepadCombination Gamepad combination to try.
    */
-  function testGestureInProgress(testCaseName, keyEvent) {
+  function testGestureInProgress(testCaseName, gamepadCombination) {
     test(testCaseName, function() {
       sinon.stub(Blockly.Gesture, 'inProgress').returns(true);
-      Blockly.onKeyDown(keyEvent);
+      createNavigatorGetGamepadsStub(gamepadCombination);
+      this.clock.runToFrame();
       const hideChaffSpy = sinon.spy(Blockly, 'hideChaff');
       const copySpy = sinon.spy(Blockly, 'copy');
       sinon.assert.notCalled(copySpy);
@@ -48,13 +55,14 @@ suite('Shortcut Tests', function() {
    * Creates a test for not running a shortcut when a the cursor is not on a
    * block.
    * @param {string} testCaseName The name of the test case.
-   * @param {Object} keyEvent Mocked key down event. Use createKeyDownEvent.
+   * @param {GamepadCombination} gamepadCombination Gamepad combination to try.
    */
-  function testCursorOnShadowBlock(testCaseName, keyEvent) {
+  function testCursorOnShadowBlock(testCaseName, gamepadCombination) {
     test(testCaseName, function() {
       const hideChaffSpy = sinon.spy(Blockly, 'hideChaff');
       const copySpy = sinon.spy(Blockly, 'copy');
-      Blockly.onKeyDown(keyEvent);
+      createNavigatorGetGamepadsStub(gamepadCombination);
+      this.clock.runToFrame();
       sinon.assert.notCalled(copySpy);
       sinon.assert.notCalled(hideChaffSpy);
     });
@@ -63,12 +71,13 @@ suite('Shortcut Tests', function() {
   /**
    * Creates a test for not running a shortcut when the block is not deletable.
    * @param {string} testCaseName The name of the test case.
-   * @param {Object} keyEvent Mocked key down event. Use createKeyDownEvent.
+   * @param {GamepadCombination} gamepadCombination Gamepad combination to try.
    */
-  function testBlockIsNotDeletable(testCaseName, keyEvent) {
+  function testBlockIsNotDeletable(testCaseName, gamepadCombination) {
     test(testCaseName, function() {
       sinon.stub(this.basicBlock, 'isDeletable').returns(false);
-      Blockly.onKeyDown(keyEvent);
+      createNavigatorGetGamepadsStub(gamepadCombination);
+      this.clock.runToFrame();
       const hideChaffSpy = sinon.spy(Blockly, 'hideChaff');
       const copySpy = sinon.spy(Blockly, 'copy');
       sinon.assert.notCalled(copySpy);
@@ -80,21 +89,24 @@ suite('Shortcut Tests', function() {
    * Creates a test for not running a shortcut when the cursor is not on a
    * block.
    * @param {string} testCaseName The name of the test case.
-   * @param {Object} keyEvent Mocked key down event. Use createKeyDownEvent.
+   * @param {GamepadCombination} gamepadCombination Gamepad combination to try.
    */
-  function testCursorIsNotOnBlock(testCaseName, keyEvent) {
+  function testCursorIsNotOnBlock(testCaseName, gamepadCombination) {
     test(testCaseName, function() {
       const hideChaffSpy = sinon.spy(Blockly, 'hideChaff');
       const copySpy = sinon.spy(Blockly, 'copy');
-      Blockly.onKeyDown(keyEvent);
+      createNavigatorGetGamepadsStub(gamepadCombination);
+      this.clock.runToFrame();
       sinon.assert.notCalled(copySpy);
       sinon.assert.notCalled(hideChaffSpy);
     });
   }
 
   setup(function() {
-    this.jsdomCleanup =
-        require('jsdom-global')('<!DOCTYPE html><div id="blocklyDiv"></div>');
+    /** @type {FakeTimers.Clock} */
+    this.clock = FakeTimers.install();
+
+    createBlocklyDiv('blocklyDiv');
     Blockly.utils.dom.getFastTextWidthWithSizeString = function() {
       return 10;
     };
@@ -104,45 +116,45 @@ suite('Shortcut Tests', function() {
       'previousStatement': null,
       'nextStatement': null,
     }]);
-    this.controller = new NavigationController();
+
+    /** @type {Navigation} */
+    this.navigation = new Navigation();
+
+    const gamepadShortcutRegistry = new GamepadShortcutRegistry();
+
+    /** @type {GamepadMonitor} */
+    this.gamepadMonitor = new GamepadMonitor(gamepadShortcutRegistry);
+
+    /** @type {NavigationController} */
+    this.controller = new NavigationController(
+        this.navigation, gamepadShortcutRegistry, this.gamepadMonitor);
     this.controller.init();
-    this.navigation = this.controller.navigation;
-    this.workspace = createNavigationWorkspace(this.navigation, true);
+
+    /** @type {Blockly.WorkspaceSvg} */
+    this.workspace = createNavigationWorkspace(/* readOnly= */ true);
     this.controller.addWorkspace(this.workspace);
+    this.controller.enable(this.workspace);
+
+    /** @type {Blockly.Block} */
     this.basicBlock = this.workspace.newBlock('basic_block');
+
+    connectFakeGamepad();
   });
 
   teardown(function() {
-    this.jsdomCleanup();
+    disconnectFakeGamepad();
     this.controller.dispose();
     delete Blockly.Blocks['basic_block'];
     this.workspace.dispose();
+    this.clock.uninstall();
   });
 
   suite('Copy', function() {
     teardown(function() {
       sinon.restore();
     });
-    const testCases = [
-      [
-        'Control C',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.C, 'NotAField',
-            [Blockly.utils.KeyCodes.CTRL]),
-      ],
-      [
-        'Meta C',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.C, 'NotAField',
-            [Blockly.utils.KeyCodes.META]),
-      ],
-      [
-        'Alt C',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.C, 'NotAField',
-            [Blockly.utils.KeyCodes.ALT]),
-      ],
-    ];
+
+    const testCases = [['Up', GamepadCombination.UP]];
 
     // Copy a block.
     suite('Simple', function() {
@@ -153,11 +165,12 @@ suite('Shortcut Tests', function() {
 
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
+        const gamepadCombination = testCase[1];
         test(testCaseName, function() {
           const hideChaffSpy = sinon.spy(Blockly, 'hideChaff');
           const copySpy = sinon.spy(Blockly, 'copy');
-          Blockly.onKeyDown(keyEvent);
+          createNavigatorGetGamepadsStub(gamepadCombination);
+          this.clock.runToFrame();
           sinon.assert.calledOnce(copySpy);
           sinon.assert.calledOnce(hideChaffSpy);
         });
@@ -173,8 +186,8 @@ suite('Shortcut Tests', function() {
       });
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testCursorIsNotOnBlock(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testCursorIsNotOnBlock(testCaseName, gamepadCombination);
       });
     });
 
@@ -187,8 +200,8 @@ suite('Shortcut Tests', function() {
       });
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testCursorOnShadowBlock(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testCursorOnShadowBlock(testCaseName, gamepadCombination);
       });
     });
 
@@ -196,8 +209,8 @@ suite('Shortcut Tests', function() {
     suite('Not called when readOnly is true', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        runReadOnlyTest(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        runReadOnlyTest(testCaseName, gamepadCombination);
       });
     });
 
@@ -205,8 +218,8 @@ suite('Shortcut Tests', function() {
     suite('Gesture in progress', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testGestureInProgress(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testGestureInProgress(testCaseName, gamepadCombination);
       });
     });
 
@@ -214,8 +227,8 @@ suite('Shortcut Tests', function() {
     suite('Block is not deletable', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testBlockIsNotDeletable(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testBlockIsNotDeletable(testCaseName, gamepadCombination);
       });
     });
   });
@@ -230,26 +243,19 @@ suite('Shortcut Tests', function() {
       sinon.restore();
     });
 
-    const testCases = [
-      [
-        'Delete',
-        createKeyDownEvent(Blockly.utils.KeyCodes.DELETE, 'NotAField'),
-      ],
-      [
-        'Backspace',
-        createKeyDownEvent(Blockly.utils.KeyCodes.BACKSPACE, 'NotAField'),
-      ],
-    ];
+    const testCases = [['Left', GamepadCombination.LEFT]];
+
     // Delete a block.
     suite('Simple', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
+        const gamepadCombination = testCase[1];
         test(testCaseName, function() {
           const deleteSpy = sinon.spy(Blockly, 'deleteBlock');
           const moveCursorSpy =
               sinon.spy(this.navigation, 'moveCursorOnBlockDelete');
-          Blockly.onKeyDown(keyEvent);
+          createNavigatorGetGamepadsStub(gamepadCombination);
+          this.clock.runToFrame();
           sinon.assert.calledOnce(moveCursorSpy);
           sinon.assert.calledOnce(deleteSpy);
         });
@@ -259,33 +265,14 @@ suite('Shortcut Tests', function() {
     suite('Not called when readOnly is true', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        runReadOnlyTest(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        runReadOnlyTest(testCaseName, gamepadCombination);
       });
     });
   });
 
   suite('Cut', function() {
-    const testCases = [
-      [
-        'Control X',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.X, 'NotAField',
-            [Blockly.utils.KeyCodes.CTRL]),
-      ],
-      [
-        'Meta X',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.X, 'NotAField',
-            [Blockly.utils.KeyCodes.META]),
-      ],
-      [
-        'Alt X',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.X, 'NotAField',
-            [Blockly.utils.KeyCodes.ALT]),
-      ],
-    ];
+    const testCases = [['Right', GamepadCombination.RIGHT]];
 
     teardown(function() {
       sinon.restore();
@@ -299,13 +286,14 @@ suite('Shortcut Tests', function() {
       });
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
+        const gamepadCombination = testCase[1];
         test(testCaseName, function() {
           const deleteSpy = sinon.spy(Blockly, 'deleteBlock');
           const copySpy = sinon.spy(Blockly, 'copy');
           const moveCursorSpy =
               sinon.spy(this.navigation, 'moveCursorOnBlockDelete');
-          Blockly.onKeyDown(keyEvent);
+          createNavigatorGetGamepadsStub(gamepadCombination);
+          this.clock.runToFrame();
           sinon.assert.calledOnce(copySpy);
           sinon.assert.calledOnce(deleteSpy);
           sinon.assert.calledOnce(moveCursorSpy);
@@ -322,8 +310,8 @@ suite('Shortcut Tests', function() {
       });
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testCursorIsNotOnBlock(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testCursorIsNotOnBlock(testCaseName, gamepadCombination);
       });
     });
 
@@ -336,8 +324,8 @@ suite('Shortcut Tests', function() {
       });
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testCursorOnShadowBlock(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testCursorOnShadowBlock(testCaseName, gamepadCombination);
       });
     });
 
@@ -345,8 +333,8 @@ suite('Shortcut Tests', function() {
     suite('Not called when readOnly is true', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        runReadOnlyTest(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        runReadOnlyTest(testCaseName, gamepadCombination);
       });
     });
 
@@ -354,8 +342,8 @@ suite('Shortcut Tests', function() {
     suite('Gesture in progress', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testGestureInProgress(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testGestureInProgress(testCaseName, gamepadCombination);
       });
     });
 
@@ -363,33 +351,14 @@ suite('Shortcut Tests', function() {
     suite('Block is not deletable', function() {
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
-        testBlockIsNotDeletable(testCaseName, keyEvent);
+        const gamepadCombination = testCase[1];
+        testBlockIsNotDeletable(testCaseName, gamepadCombination);
       });
     });
   });
 
   suite('Paste', function() {
-    const testCases = [
-      [
-        'Control X',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.V, 'NotAField',
-            [Blockly.utils.KeyCodes.CTRL]),
-      ],
-      [
-        'Meta X',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.V, 'NotAField',
-            [Blockly.utils.KeyCodes.META]),
-      ],
-      [
-        'Alt X',
-        createKeyDownEvent(
-            Blockly.utils.KeyCodes.V, 'NotAField',
-            [Blockly.utils.KeyCodes.ALT]),
-      ],
-    ];
+    const testCases = [['Down', GamepadCombination.DOWN]];
 
     teardown(function() {
       sinon.restore();
@@ -403,10 +372,11 @@ suite('Shortcut Tests', function() {
       });
       testCases.forEach(function(testCase) {
         const testCaseName = testCase[0];
-        const keyEvent = testCase[1];
+        const gamepadCombination = testCase[1];
         test(testCaseName, function() {
           const pasteSpy = sinon.stub(this.navigation, 'paste');
-          Blockly.onKeyDown(keyEvent);
+          createNavigatorGetGamepadsStub(gamepadCombination);
+          this.clock.runToFrame();
           sinon.assert.calledOnce(pasteSpy);
         });
       });

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,4 +1,9 @@
-// const Blockly = require('blockly/node');
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import Blockly from 'blockly';
 import sinon from 'sinon';
 import {GamepadCombination} from '../src/gamepad';

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,12 +1,22 @@
-/**
- * @license
- * Copyright 2021 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
+// const Blockly = require('blockly/node');
+import Blockly from 'blockly';
+import sinon from 'sinon';
+import {GamepadCombination} from '../src/gamepad';
+import {Navigation} from '../src/navigation';
+import * as Constants from '../src/constants';
 
-const {Constants} = require('../src/index');
-const {Navigation} = require('../src/index');
-const Blockly = require('blockly/node');
+/**
+ * Appends a div with the given ID to the document body.
+ * @param {string} id The ID to assign to the element.
+ */
+export function createBlocklyDiv(id) {
+  if (document.getElementById(id)) {
+    return;
+  }
+  const element = document.createElement('div');
+  element.id = id;
+  document.body.append(element);
+}
 
 /**
  * Creates a workspace for testing gamepad navigation.
@@ -39,6 +49,8 @@ export function createNavigationWorkspace(
     readOnly: readOnly,
   });
   if (enableGamepadNav) {
+    // TODO(pkukkapalli): replace this with NavigationController for
+    // consistency.
     navigation.addWorkspace(workspace);
     navigation.enableGamepadAccessibility(workspace);
     navigation.setState(workspace, Constants.STATE.WORKSPACE);
@@ -47,39 +59,31 @@ export function createNavigationWorkspace(
 }
 
 /**
- * Creates a key down event used for testing.
- * @param {number} keyCode The keycode for the event. Use Blockly.utils.KeyCodes
- *     enum.
- * @param {string} type The type of the target. This only matters for the
- *     Blockly.utils.isTargetInput method.
- * @param {Array<number>} modifiers A list of modifiers. Use
- *     Blockly.utils.KeyCodes enum.
- * @return {Object} The mocked keydown
- * event.
+ * Fires an event to indicate that a gamepad has been connected.
  */
-export function createKeyDownEvent(keyCode, type, modifiers) {
-  const event = {
-    keyCode: keyCode,
-    target: {type: type},
-    getModifierState: function(name) {
-      if (name == 'Shift' && this.shiftKey) {
-        return true;
-      } else if (name == 'Control' && this.ctrlKey) {
-        return true;
-      } else if (name == 'Meta' && this.metaKey) {
-        return true;
-      } else if (name == 'Alt' && this.altKey) {
-        return true;
-      }
-      return false;
-    },
-    preventDefault: function() {},
-  };
-  if (modifiers && modifiers.length > 0) {
-    event.altKey = modifiers.indexOf(Blockly.utils.KeyCodes.ALT) > -1;
-    event.ctrlKey = modifiers.indexOf(Blockly.utils.KeyCodes.CTRL) > -1;
-    event.metaKey = modifiers.indexOf(Blockly.utils.KeyCodes.META) > -1;
-    event.shiftKey = modifiers.indexOf(Blockly.utils.KeyCodes.SHIFT) > -1;
-  }
-  return event;
+export function connectFakeGamepad() {
+  const event = new Event('gamepadconnected');
+  event.gamepad = {index: 0};
+  window.dispatchEvent(event);
+}
+
+/**
+ * Fires an event to indicate that a gamepad has been disconnected.
+ */
+export function disconnectFakeGamepad() {
+  const event = new Event('gamepaddisconnected');
+  event.gamepad = {index: 0};
+  window.dispatchEvent(event);
+}
+
+/**
+ * Stubs the navigator.getGamepads method to have a gamepad with the given
+ * button/axis combination active.
+ * @param {!GamepadCombination} gamepadCombination The gamepad combination to
+ *     populate the gamepad with.
+ * @return {sinon.SinonStub<[], Gamepad[]>} The created stub.
+ */
+export function createNavigatorGetGamepadsStub(gamepadCombination) {
+  return sinon.stub(navigator, 'getGamepads')
+      .callsFake(() => [gamepadCombination.asGamepad()]);
 }


### PR DESCRIPTION
There are a number of major changes in commit:

1. Replace plain Mocha tests with Karma+Mocha. This enables testing in a real browser rather than using JSDom, which is more difficult to configure, and is less of "real" test.
2. Replace usages of Blockly events with a GamepadMonitor class that listens for updates from a gamepad and triggers shortcuts.
3. Replace usages of Blockly's ShortcutRegistry with GamepadShortcutRegistry. The Blockly version only supports keyboards.

All tests now pass, but there is still one that is skipped on every invocation. In addition, no manual testing on the actual usability of the gamepad has been done yet.

See NOTES.md for remaining work.